### PR TITLE
Responsive modal width

### DIFF
--- a/src/components/mgImage/mgImage.js
+++ b/src/components/mgImage/mgImage.js
@@ -92,7 +92,7 @@ angular
 		},
 		template: `
 			<div id="modal-mgImage-{{$ctrl.config.id}}" class="modal fade">
-				<div class="modal-dialog" style="width: 830px">
+				<div class="modal-dialog modal-lg">
 					<div class="modal-content">
 						<div class="modal-header">
 							<a class="close" data-dismiss="modal"><i class="fa fa-times"></i></a>
@@ -100,7 +100,7 @@ angular
 						</div>
 						<div class="modal-body">
 							<div ng-if="$ctrl.modalShown">
-								<ui-scribble editable="true" callback="$ctrl.getImage(dataURI, blob)" width="800" height="600"></ui-scribble>
+								<ui-scribble editable="true" callback="$ctrl.getImage(dataURI, blob)" width="100%" height="600"></ui-scribble>
 							</div>
 						</div>
 						<div class="modal-footer">


### PR DESCRIPTION
Note: ui-scribble should be updated so that:
- by default it uses width: auto if a width is not given
- only add 'px' unit when the value given does not have a unit

Right now passing width=100% to ui-scribble is working because ui-scribble adds the 'px' so the width on the scribble area and nav becomes '100%px' which is not valid so that rule is ignored in the browser. The browser defaults to auto.