### PR TITLE
'Flexible' label width when 2nd col has no content

### DIFF
--- a/src/components/mgContainer/mgContainer.js
+++ b/src/components/mgContainer/mgContainer.js
@@ -46,12 +46,12 @@ angular
 				<a class="btn btn-sm btn-success"><i class="fa fa-plus"></i> Add widget</a>
 			</div>
 			<div ng-repeat="w in $ctrl.config.items track by w.id" ng-switch="w.type" data-path="{{w.id}}" class="form-group row" ng-class="w.mgValidation == 'error' && 'has-error'">
-				<label ng-if="w.showTitle || w.showTitle===undefined" class="col-sm-3 col-form-label control-label">{{w.title}}</label>
-				<div ng-class="w.showTitle || w.showTitle===undefined ? 'col-sm-9' : 'col-sm-12'">
+				<label ng-if="w.showTitle || w.showTitle===undefined" class="control-label text-left" ng-class="!(w.type=='mgLabel' || w.type=='mgHtml') || ($ctrl.data[w.id] || w.text) ? 'col-sm-3' : 'col-sm-12'">{{w.title}}</label>
+				<div ng-if="!(w.type=='mgLabel' || w.type=='mgHtml') || ($ctrl.data[w.id] || w.text)" ng-class="w.showTitle || w.showTitle===undefined ? 'col-sm-9' : 'col-sm-12'">
 			` + _.map($macgyver.widgets, w => `<div ng-switch-when="${w.id}">${w.template}</div>`).join('\n') + `
 					<div ng-switch-default class="alert alert-danger">Unknown MacGyver widget type : "{{w.type}}"</div>
-					<div ng-if="w.help" class="help-block">{{w.help}}</div>
 				</div>
+				<div class="help-block" ng-if="w.help" ng-class="w.showTitle || w.showTitle===undefined ? 'col-sm-9 col-sm-offset-3' : 'col-sm-12'">{{w.help}}</div>
 			</div>
 		`,
 	})


### PR DESCRIPTION
Hide the second column when it's not necessary.
- If it is a mgLabel, mgHtml component without any content (w.text or $ctrl.data[w.id])

First column expands when second column is hidden
- .col-sm-3 when second column is visible
- .col-sm-12 when second column is hidden